### PR TITLE
Bugfix: Makefile can install now (typo)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC=g++
 CPPFLAGS=-lX11 -Wall -Wextra -fPIE -O2 -D_FORTIFY_SOURCE=2
 SOURCE=swallow.cpp
 TARGET=swallow
-PREFIX=/usr/loca/bin/
+PREFIX=/usr/local/bin/
 
 build: $(TARGET)
 	$(CC) $(CPPFLAGS) $(SOURCE) -o $(TARGET)


### PR DESCRIPTION
Crazy directory `/usr/bin/loca/` doesn't exist.